### PR TITLE
Use setuptools rather than distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name = 'Flask-Auth',
       version = '0.4',


### PR DESCRIPTION
The setuptools module has more advanced features, like the
`--single-version-externally-managed` flag for packing the module in RPMs.

This will help with packaging Flask-Auth for use with yum and the like.
